### PR TITLE
allow empty strings as row keys

### DIFF
--- a/sqlagg/base.py
+++ b/sqlagg/base.py
@@ -188,7 +188,7 @@ class QueryContext(object):
                 elif len(qm.group_by) > 1:
                     row_key = tuple([r[group] for group in qm.group_by])
 
-                if row_key:
+                if row_key is not None:
                     row = data.setdefault(row_key, {})
                     row.update(kvp for kvp in r.items())
                 else:


### PR DESCRIPTION
this was breaking something for user configurable reports if the column you were aggregating by had empty values. this changes the behavior from putting empty values in the root namespace to putting them nested with a key of an empty string. i don't know if there are wider implications of this change that will break something I don't understand.
