### PR TITLE
don't use literal alias in group by

### DIFF
--- a/sqlagg/base.py
+++ b/sqlagg/base.py
@@ -90,7 +90,9 @@ class SimpleQueryMeta(QueryMeta):
                     if group_key in cols:
                         query.append_group_by(table.c[group_key])
                     elif group_key in alias:
-                        query.append_group_by(group_key)
+                        aliased_column = [col.build_column(table) for col in self.columns if col.alias == group_key]
+                        assert len(aliased_column) == 1
+                        query.append_group_by(aliased_column[0])
 
             for c in self.columns:
                 query.append_column(c.build_column(table))


### PR DESCRIPTION
```group_key``` is unescaped when passed to ```query.append_group_by```, so instead pass the actual column

@snopoke @czue @NoahCarnahan 