### PR TITLE
Allow grouping by aliased column

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name='sqlagg',
-    version='0.3.1',
+    version='0.3.2',
     description='SQL aggregation tool',
     author='Dimagi',
     author_email='dev@dimagi.com',

--- a/sqlagg/base.py
+++ b/sqlagg/base.py
@@ -62,7 +62,7 @@ class SimpleQueryMeta(QueryMeta):
         if self.group_by:
             groups = list(self.group_by)
             for c in self.columns:
-                if c.column_name in groups:
+                if c.column_name in groups and not c.alias:
                     groups.remove(c.column_name)
                 elif c.alias in groups:
                     groups.remove(c.alias)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -92,6 +92,26 @@ class TestSqlAgg(BaseTest, TestCase):
         self.assertEqual(data['user2']['sum_a'], 2)
         self.assertEqual(data['user2']['count_a'], 2)
 
+    def test_group_by_missing_column(self):
+        vc = QueryContext("user_table", group_by=["user"])
+        i_a = SumColumn("indicator_a")
+        vc.append_column(i_a)
+        data = vc.resolve(self.session.connection())
+
+        self.assertEqual(data['user1']['indicator_a'], 4)
+        self.assertEqual(data['user2']['indicator_a'], 2)
+
+    def test_group_by_aliased_column(self):
+        vc = QueryContext("user_table", group_by=["user"])
+        user = SimpleColumn("user", alias="aliased_column")
+        i_a = SumColumn("indicator_a")
+        vc.append_column(user)
+        vc.append_column(i_a)
+        data = vc.resolve(self.session.connection())
+
+        self.assertEqual(data['user1']['indicator_a'], 4)
+        self.assertEqual(data['user2']['indicator_a'], 2)
+
     def test_custom_view(self):
         from sqlalchemy import func
         vc = QueryContext("user_table", filters=None, group_by=[])


### PR DESCRIPTION
Currently, one can group by a table column that has not had a corresponding `SqlAggColumn` explicitly added to the query context. This is demonstrated by `test_group_by_missing_column()`.

However, if one attempts to group by a table column that has a `SqlAggColumn` that provides an alias for the column name in the query context, a runtime error is encountered. This is demonstrated by `test_group_by_aliased_column()`. This PR alters this behavior, so that grouping by a column that has been aliased behaves in the same way as grouping by a column that hasn't been added to the query context.

@snopoke, does this seem like the appropriate behavior to you?