### PR TITLE
coerce averages to floats

### DIFF
--- a/sqlagg/columns.py
+++ b/sqlagg/columns.py
@@ -54,6 +54,11 @@ class MinColumn(BaseColumn):
 class MeanColumn(BaseColumn):
     aggregate_fn = func.avg
 
+    def get_value(self, row):
+        value = super(MeanColumn, self).get_value(row)
+        if value is not None:
+            return float(value)
+
 
 class CountUniqueColumn(BaseColumn):
     aggregate_fn = lambda _, column: func.count(distinct(column))


### PR DESCRIPTION
@snopoke i'm not sure about this change.

this was an alternate approach to https://github.com/dimagi/commcare-hq/pull/9435 to solve http://manage.dimagi.com/default.asp?188706

for whatever reason sqlalchemy spits out strings for `.avg` which seems weird, but the other approach seemed much lower impact. feel free to merge or close depending on what you think about this.