### PR TITLE
fix column keys so that query grouping works

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,17 @@ try:
 except ImportError:
     from distutils.core import setup
 
+tests_require=[
+    'nose',
+    'SQLAlchemy-Fixtures>=0.1.5',
+    'fixture>=1.4',
+    'psycopg2'
+]
+
+
 setup(
     name='sqlagg',
-    version='0.9.2',
+    version='0.10.0',
     description='SQL aggregation tool',
     author='Dimagi',
     author_email='dev@dimagi.com',
@@ -17,13 +25,11 @@ setup(
     install_requires=[
         'SQLAlchemy>=1.0.9',
     ],
-    tests_require=[
-        'nose',
-        'SQLAlchemy-Fixtures>=0.1.5',
-        'fixture>=1.4',
-        'psycopg2'
-    ],
+    tests_require=tests_require,
     setup_requires=['nose'],
+    extras_require={
+        'test': tests_require,
+    },
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",

--- a/sqlagg/base.py
+++ b/sqlagg/base.py
@@ -271,6 +271,7 @@ class QueryContext(object):
 
     def get_query_strings(self, connection):
         """Useful for debugging large queryies"""
+        self.connection = connection
         return [
             qm.get_query_string(self.metadata, connection)
             for qm in self.query_meta.values()

--- a/sqlagg/base.py
+++ b/sqlagg/base.py
@@ -321,7 +321,11 @@ class BaseColumn(SqlAggColumn):
 
     @property
     def column_key(self):
-        return self.table_name, str(self.filters), str(self.group_by)
+        return (
+            self.table_name,
+            tuple(sorted(self.filters)) if self.filters else None,
+            tuple(self.group_by) if self.group_by else None
+        )
 
     @property
     def sql_column(self):
@@ -345,7 +349,11 @@ class CustomQueryColumn(BaseColumn, QueryColumn):
 
     @property
     def column_key(self):
-        return self.name, self.key, self.table_name, str(self.filters), str(self.group_by)
+        return (
+            self.name, self.key, self.table_name,
+            tuple(sorted(self.filters)) if self.filters else None,
+            tuple(self.group_by) if self.group_by else None
+        )
 
 
 class AliasColumn(SqlAggColumn):

--- a/sqlagg/base.py
+++ b/sqlagg/base.py
@@ -81,7 +81,7 @@ class SimpleQueryMeta(QueryMeta):
 
     def get_query_string(self, metadata, connection):
         query = self._build_query(metadata)
-        return query.compile(connection)
+        return str(query.compile(connection))
 
     def count(self, metadata, connection, filter_values):
         assert self.start is None

--- a/sqlagg/filters.py
+++ b/sqlagg/filters.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import collections
+from functools import total_ordering
 
 from sqlalchemy import bindparam, text
 from sqlalchemy.sql import operators, and_, or_, not_
@@ -20,9 +21,14 @@ def get_column(table, column_name):
     raise ColumnNotFoundException('column with name "%s" not found' % column_name)
 
 
+@total_ordering
 class SqlFilter(NotEqMixin):
     def build_expression(self, table):
         raise NotImplementedError()
+
+    def __lt__(self, other):
+        """Ordering is required for consistent sorting when creating column keys"""
+        return hash(self) < hash(other)
 
 
 class RawFilter(SqlFilter):

--- a/sqlagg/filters.py
+++ b/sqlagg/filters.py
@@ -44,9 +44,13 @@ class RawFilter(SqlFilter):
     def __hash__(self):
         return hash((RawFilter, self.expression))
 
+    def __repr__(self):
+        return "SQL({})".format(self.expression)
+
 
 class BasicFilter(SqlFilter):
     operator = None
+    operator_string = None
 
     def __init__(self, column_name, parameter, operator=None):
         self.column_name = column_name
@@ -70,6 +74,9 @@ class BasicFilter(SqlFilter):
 
     def __hash__(self):
         return hash((type(self), self.column_name, self.parameter, self.operator))
+
+    def __repr__(self):
+        return "SQL({} {} {})".format(self.column_name, self.operator_string, self.parameter)
 
 
 class BetweenFilter(SqlFilter):
@@ -96,32 +103,39 @@ class BetweenFilter(SqlFilter):
 
 class GTFilter(BasicFilter):
     operator = operators.gt
+    operator_string = '>'
 
 
 class GTEFilter(BasicFilter):
     operator = operators.ge
+    operator_string = '>='
 
 
 class LTFilter(BasicFilter):
     operator = operators.lt
+    operator_string = '<'
 
 
 class LTEFilter(BasicFilter):
     operator = operators.le
+    operator_string = '<='
 
 
 class EQFilter(BasicFilter):
     operator = operators.eq
+    operator_string = '='
 
 
 class NOTEQFilter(BasicFilter):
     operator = operators.ne
+    operator_string = '!='
 
 
 class INFilter(BasicFilter):
     """
     This filter requires that the parameter value be a tuple.
     """
+    operator_string = 'in'
     def build_expression(self, table):
         assert isinstance(self.parameter, collections.Iterable)
         return operators.in_op(
@@ -154,6 +168,9 @@ class ISNULLFilter(SqlFilter):
     def __hash__(self):
         return hash((ISNULLFilter, self.column_name))
 
+    def __repr__(self):
+        return "SQL({} IS NULL)"
+
 
 class NOTNULLFilter(SqlFilter):
     def __init__(self, column_name):
@@ -167,6 +184,9 @@ class NOTNULLFilter(SqlFilter):
 
     def __hash__(self):
         return hash((NOTNULLFilter, self.column_name))
+
+    def __repr__(self):
+        return "SQL({} NOT NULL)"
 
 
 class NOTFilter(SqlFilter):
@@ -200,6 +220,9 @@ class ANDFilter(SqlFilter):
     def __hash__(self):
         return hash((NOTFilter,) + tuple(sorted(self.filters)))
 
+    def __repr__(self):
+        return "SQL({})".format(' AND '.join(self.filters))
+
 
 class ORFilter(SqlFilter):
     """
@@ -217,6 +240,9 @@ class ORFilter(SqlFilter):
 
     def __hash__(self):
         return hash((ORFilter,) + tuple(sorted(self.filters)))
+
+    def __repr__(self):
+        return "SQL({})".format(' OR '.join(self.filters))
 
 
 RAW = RawFilter

--- a/sqlagg/filters.py
+++ b/sqlagg/filters.py
@@ -19,9 +19,6 @@ class SqlFilter(object):
     def build_expression(self, table):
         raise NotImplementedError()
 
-    def __str__(self):
-        return 'SqlFilter(%s)' % self.build_expression()
-
 
 class RawFilter(SqlFilter):
     def __init__(self, expression):

--- a/sqlagg/filters.py
+++ b/sqlagg/filters.py
@@ -5,7 +5,7 @@ import collections
 from sqlalchemy import bindparam, text
 from sqlalchemy.sql import operators, and_, or_, not_
 
-from sqlagg.exceptions import ColumnNotFoundException
+from sqlagg.exceptions import ColumnNotFoundException, SqlAggException
 
 
 def get_column(table, column_name):
@@ -39,7 +39,7 @@ class BasicFilter(SqlFilter):
 
     def build_expression(self, table):
         if not self.operator:
-            raise 'Operator missing'
+            raise SqlAggException('Operator missing')
 
         return self.operator(get_column(table, self.column_name), bindparam(self.parameter))
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -71,8 +71,8 @@ class TestSqlAgg(BaseTest, TestCase):
         vc.append_column(user)
         vc.append_column(i_a)
         vc.append_column(i_b)
+        self.assertEquals(2, len(vc.get_query_strings(self.session.connection())))
         data = vc.resolve(self.session.connection(), filter_values)
-
         self.assertEqual(data['user1']['indicator_a'], 1)
         self.assertNotIn('indicator_b', data['user1'])
         self.assertEqual(data['user2']['indicator_a'], 0)


### PR DESCRIPTION
Previously the following query would result in 2 SQL queries instead of 1 because the column key hash did not work:

```python
vc = QueryContext("user_table", filters=filters, group_by=["user"])
vc.append_column(SumColumn("indicator_a", filters=[GT('date', 'enddate')]))
vc.append_column(SumColumn("indicator_b", filters=[GT('date', 'enddate')]))
```