### PR TITLE
add NonzeroSumColumn and test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ tests_require=[
 
 setup(
     name='sqlagg',
-    version='0.10.1',
+    version='0.10.2',
     description='SQL aggregation tool',
     author='Dimagi',
     author_email='dev@dimagi.com',

--- a/sqlagg/columns.py
+++ b/sqlagg/columns.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from sqlalchemy import func, distinct, case, text
+from sqlalchemy import func, distinct, case, text, cast, Integer
 from .queries import MedianQueryMeta
 from .base import BaseColumn, CustomQueryColumn, SqlColumn
 import six
@@ -61,6 +61,10 @@ class MeanColumn(BaseColumn):
         value = super(MeanColumn, self).get_value(row)
         if value is not None:
             return float(value)
+
+
+class NonzeroSumColumn(BaseColumn):
+    aggregate_fn = lambda _, column: cast(func.sum(column) > 0, Integer)
 
 
 class CountUniqueColumn(BaseColumn):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -11,6 +11,7 @@ class UserData(DataSet):
         indicator_a = 1
         indicator_b = 1
         indicator_c = 1
+        indicator_d = 0
 
     class r2:
         user = "user1"
@@ -24,12 +25,14 @@ class UserData(DataSet):
         indicator_a = 0
         indicator_b = 3
         indicator_c = 2
+        indicator_d = 0
 
     class r4:
         user = "user2"
         date = datetime.date(2013, 3, 1)
         indicator_a = 2
         indicator_b = 1
+
 
 
 class RegionData(DataSet):

--- a/tests/models.py
+++ b/tests/models.py
@@ -12,7 +12,8 @@ user_table = Table("user_table",
                    Column("date", DATE, primary_key=True, autoincrement=False),
                    Column("indicator_a", INT),
                    Column("indicator_b", INT),
-                   Column("indicator_c", INT))
+                   Column("indicator_c", INT),
+                   Column("indicator_d", INT))
 
 
 class UserTable(object):

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -7,7 +7,8 @@ from . import BaseTest, engine
 from sqlalchemy.orm import sessionmaker
 
 from sqlagg import *
-from sqlagg.columns import MonthColumn, DayColumn, YearColumn, WeekColumn, CountUniqueColumn, DayOfWeekColumn, DayOfYearColumn, YearQuarterColumn
+from sqlagg.columns import MonthColumn, DayColumn, YearColumn, WeekColumn, CountUniqueColumn, DayOfWeekColumn, \
+    DayOfYearColumn, YearQuarterColumn, NonzeroSumColumn
 
 Session = sessionmaker()
 
@@ -73,6 +74,12 @@ class TestSqlAggViews(BaseTest, TestCase):
 
     def test_unique_2(self):
         self._test_view(CountUniqueColumn("sub_region", table_name="region_table"), 3)
+
+    def test_nonzero_sum(self):
+        self._test_view(NonzeroSumColumn("indicator_a"), 1)
+        self._test_view(NonzeroSumColumn("indicator_b"), 1)
+        self._test_view(NonzeroSumColumn("indicator_c"), 1)
+        self._test_view(NonzeroSumColumn("indicator_d"), 0)
 
     def test_median(self):
         self._test_view(MedianColumn("indicator_a"), 1.5)


### PR DESCRIPTION
this is a useful column in reporting, for example, to answer the question "did the case receive a visit this month" and is useful to be an `int` so you can sum them.

I wasn't 100% sure it belonged here, but it seemed natural. Of course, we can also define these in HQ if we think they aren't more broadly useful.