### PR TITLE
Revert changes to group by alias

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ tests_require=[
 
 setup(
     name='sqlagg',
-    version='0.10.3',
+    version='0.10.4',
     description='SQL aggregation tool',
     author='Dimagi',
     author_email='dev@dimagi.com',

--- a/sqlagg/base.py
+++ b/sqlagg/base.py
@@ -141,9 +141,9 @@ class SimpleQueryMeta(QueryMeta):
                     if group_key in cols:
                         query.append_group_by(table.c[group_key])
                     elif group_key in alias:
-                        aliased_columns = [col for col in self.columns if col.alias == group_key]
+                        aliased_columns = [col.build_column(table) for col in self.columns if col.alias == group_key]
                         assert len(aliased_columns) == 1, "Only one column should have this alias"
-                        query.append_group_by(group_key)
+                        query.append_group_by(aliased_columns[0])
 
             for c in self.columns:
                 query.append_column(c.build_column(table))


### PR DESCRIPTION
Reverting one of the changes introduced in https://github.com/dimagi/sql-agg/pull/49

This caused an issue with CCHQ UCRs which attempt to group by a column name that exists in both the report and the data source.  [Here's a test which reproduces the issue](https://github.com/dimagi/commcare-hq/commit/dc7c72bfbc57795463f73946a367e9de5762d800).

I do think the issue here is more that UCR allows you to do something that perhaps it shouldn't, and would like to see a fix there to prevent that, but figure we should revert to this behavior in the meantime.