### PR TITLE
Make the whens clauses appear in a consistent order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ tests_require=[
 
 setup(
     name='sqlagg',
-    version='0.10.4',
+    version='0.10.5',
     description='SQL aggregation tool',
     author='Dimagi',
     author_email='dev@dimagi.com',

--- a/sqlagg/columns.py
+++ b/sqlagg/columns.py
@@ -122,12 +122,12 @@ class ConditionalColumn(SqlColumn):
         if self.column_name:
             expr = case(value=sql_table.c[self.column_name], whens=self.whens, else_=self.else_)
         else:
-            whens = {}
+            whens = []
             for when, then in self.whens.items():
                 if isinstance(then, six.string_types):
-                    whens[text(when)] = text(then)
+                    whens.append((text(when), text(then)))
                 else:
-                    whens[text(when)] = then
+                    whens.append((text(when), then))
 
             expr = case(whens=whens, else_=self.else_)
 

--- a/sqlagg/columns.py
+++ b/sqlagg/columns.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from collections import OrderedDict
 from sqlalchemy import func, distinct, case, text, cast, Integer
 from .queries import MedianQueryMeta
 from .base import BaseColumn, CustomQueryColumn, SqlColumn
@@ -79,7 +80,9 @@ class MedianColumn(CustomQueryColumn):
 class ConditionalAggregation(BaseColumn):
     def __init__(self, key=None, whens=None, else_=None, *args, **kwargs):
         super(ConditionalAggregation, self).__init__(key, *args, **kwargs)
-        self.whens = whens or {}
+        # This appears in both the SELECT block and the GROUP BY block
+        # Until that changes, it must appear in a deterministic order
+        self.whens = OrderedDict(sorted((whens or {}).items()))
         self.else_ = else_
 
         assert self.key or self.alias, "Column must have either a key or an alias"


### PR DESCRIPTION
The "whens" clauses are specified in a dict, which means the ordering is arbitrary.  Since we ran into [issues with aliasing](https://github.com/dimagi/sql-agg/pull/50), the case expression is repeated in the `SELECT` and `GROUP BY` expressions.  It must be identical in these places, otherwise postgres doesn't recognize it and thinks that the `SELECT` case expression isn't part of the `GROUP BY`.