### PR TITLE
return all rows even when no grouping is taking place

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ tests_require=[
 
 setup(
     name='sqlagg',
-    version='0.16.1',
+    version='0.17.0-beta',
     description='SQL aggregation tool',
     author='Dimagi',
     author_email='dev@dimagi.com',

--- a/sqlagg/base.py
+++ b/sqlagg/base.py
@@ -240,7 +240,11 @@ class QueryContext(object):
         """
         Returns a dict containing the data of the following format:
         * If group_by == [] or None
-            return a dict mapping column names to values: {'col_a': 1....}
+            return a dict mapping row numbers to row data:
+            e.g. {
+                    1: {'col_a': 1....}
+                    2: {...}
+                }
         * If len(group_by) == 1
             return a dict mapping groupings to that group levels data
             e.g. {
@@ -260,22 +264,19 @@ class QueryContext(object):
         for qm in self.query_meta.values():
             result = qm.execute(self.connection, filter_values or {})
 
-            for r in result:
+            for index, sql_row in enumerate(result):
                 if not qm.group_by:
-                    row_key = None
+                    row_key = index
                 elif len(qm.group_by) == 1:
-                    row_key = r[qm.group_by[0]]
+                    row_key = sql_row[qm.group_by[0]]
                 elif len(qm.group_by) > 1:
-                    row_key = tuple([r[group] for group in qm.group_by])
+                    row_key = tuple([sql_row[group] for group in qm.group_by])
 
-                if qm.group_by:
-                    if row_key is None:
-                        # null values coming out of the database wreak havoc elsewhere in the code
-                        row_key = ''
-                    row = data.setdefault(row_key, {})
-                    row.update(kvp for kvp in r.items())
-                else:
-                    data.update(kvp for kvp in r.items())
+                if row_key is None:
+                    # null values coming out of the database wreak havoc elsewhere in the code
+                    row_key = ''
+                row = data.setdefault(row_key, {})
+                row.update(kvp for kvp in sql_row.items())
 
         return data
 

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -88,8 +88,9 @@ class TestSqlAggViews(BaseTest, TestCase):
         vc.append_column(i_a)
         vc.append_column(i_a2)
         data = vc.resolve(self.session.connection())
-        self.assertEqual(i_a.get_value(data), 6)
-        self.assertEqual(i_a2.get_value(data), 6)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(i_a.get_value(data[0]), 6)
+        self.assertEqual(i_a2.get_value(data[0]), 6)
 
     def test_alias_column_with_aliases(self):
         vc = QueryContext("user_table")
@@ -98,8 +99,9 @@ class TestSqlAggViews(BaseTest, TestCase):
         vc.append_column(i_a)
         vc.append_column(i_a2)
         data = vc.resolve(self.session.connection())
-        self.assertEqual(i_a.get_value(data), 6)
-        self.assertEqual(i_a2.get_value(data), 6)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(i_a.get_value(data[0]), 6)
+        self.assertEqual(i_a2.get_value(data[0]), 6)
 
     def test_aggregate_column(self):
         col = AggregateColumn(lambda x, y: x + y,
@@ -185,7 +187,8 @@ class TestSqlAggViews(BaseTest, TestCase):
 
     def _test_view(self, view, expected):
         data = self._get_view_data(view)
-        value = view.get_value(data)
+        self.assertEqual(len(data), 1)
+        value = view.get_value(data[0])
         self.assertAlmostEqual(float(value), float(expected))
 
     def _get_view_data(self, view):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -136,7 +136,8 @@ class TestSqlAgg(BaseTest, TestCase):
         vc.append_column(agg_view)
         data = vc.resolve(self.session.connection(), None)
 
-        self.assertAlmostEqual(float(data["indicator_a"]), float(0.25))
+        self.assertEqual(len(data), 1)
+        self.assertAlmostEqual(float(data[0]["indicator_a"]), float(0.25))
 
     def test_multiple_tables(self):
         filters = [LT('date', 'enddate')]


### PR DESCRIPTION
This will require a major version bump since it's not backwards compatible

Currently the result formatter assumes that if there is no `group_by` that the query will only return a single result. This has lead to workarounds like adding a unique field to `group_by` so that it returns all rows.

This change will instead return all rows from the query keyed by an incrementing row index.