### PR TITLE
Use func.count which does count(*) instead of count(colum1)

### DIFF
--- a/sqlagg/base.py
+++ b/sqlagg/base.py
@@ -110,7 +110,7 @@ class SimpleQueryMeta(QueryMeta):
         self._check()
         query = self._build_query_generic(self.columns, group_by=self.group_by, filters=self.filters,
                                           distinct_on=self.distinct_on)
-        query = query.alias().count()
+        query = sqlalchemy.select([sqlalchemy.func.count()]).select_from(query.alias())
         return connection.execute(query, **filter_values).fetchall()[0][0]
 
     def totals(self, connection, filter_values, total_columns):


### PR DESCRIPTION
If colum1 has NULL values the current count implementation ignores the rows with null values in the count. This should fix https://dimagi-dev.atlassian.net/browse/SAAS-11003