### PR TITLE
add warning for using order_by_col

### DIFF
--- a/sqlagg/columns.py
+++ b/sqlagg/columns.py
@@ -89,6 +89,8 @@ class ArrayAggColumn(BaseColumn):
     """
     Perform array aggregation on a column
     Pass order_by_col to sort by another column within the group
+    Using order_by_col clause is not fully supported for partitioned databases in citus 
+    and should be used cautiously
     Example: array generated for a column col1, ordered by col2 with select clause like
     Select ARRAY_AGG(col1 ORDER BY col2), col3 ..
     """

--- a/sqlagg/columns.py
+++ b/sqlagg/columns.py
@@ -87,12 +87,13 @@ class ConditionalAggregation(BaseColumn):
 
 class ArrayAggColumn(BaseColumn):
     """
-    Perform array aggregation on a column
-    Pass order_by_col to sort by another column within the group
-    Using order_by_col clause is not fully supported for partitioned databases in citus 
-    and should be used cautiously
+    Perform array aggregation on a column.
+    Pass order_by_col to sort by another column within the group.
     Example: array generated for a column col1, ordered by col2 with select clause like
     Select ARRAY_AGG(col1 ORDER BY col2), col3 ..
+    
+    Note: Using order_by_col clause is not fully supported for partitioned tables in CitusDB 
+    and should be used cautiously.
     """
 
     def __init__(self, key, order_by_col=None, *args, **kwargs):


### PR DESCRIPTION
w/ citus order_by_col is not supported for queries that need to be run on multiple partitions

Just adding that warning to the documentation itself.

Further explanation:
When using w/ citus, the order_by_col can be used only in case of a single table or if the filtering is also done for the column(s) being used for the table partitioning so that the query is eventually run on a single partition only